### PR TITLE
[frontend] feat: add dark mode

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -24,7 +24,7 @@ const Dashboard = () => {
       <Flex flexGrow={1} overflow="hidden" height="calc(100vh - 180px)">
         {/* Recipe Cards */}
         <Box flex="2" overflowY="auto" p={4} borderRightWidth="1px">
-          <Heading size="lg" mb={4}>
+          <Heading size="xl" mb={4}>
             Your Recipes
           </Heading>
           {RECIPES.map((recipe, index) => (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
-import { Box, Flex, HStack, IconButton } from '@chakra-ui/react';
-import { FaBars } from 'react-icons/fa';
+import { Box, Flex, HStack, IconButton, useColorMode } from '@chakra-ui/react';
+import { FaBars, FaSun, FaMoon } from 'react-icons/fa';
 
 const linkItems = [
   {
@@ -44,6 +44,8 @@ const NavLink: React.FC<NavLinkProps> = ({ link: { name, href } }) => {
 };
 
 const Header = () => {
+  const { colorMode, toggleColorMode } = useColorMode();
+
   return (
     <Box bg="gray.100">
       <Flex
@@ -54,6 +56,11 @@ const Header = () => {
         px={4}
       >
         <HStack spacing={8} alignItems="center">
+          <IconButton
+            aria-label="Toggle Dark Mode"
+            icon={colorMode === 'dark' ? <FaSun /> : <FaMoon />}
+            onClick={toggleColorMode}
+          />
           {linkItems.map((link) => (
             <NavLink link={link} key={link.name} />
           ))}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,13 @@
 import Link from 'next/link';
-import { Box, Flex, HStack, IconButton, useColorMode } from '@chakra-ui/react';
-import { FaBars, FaSun, FaMoon } from 'react-icons/fa';
+import {
+  Box,
+  Flex,
+  HStack,
+  IconButton,
+  useColorMode,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import { FaSun, FaMoon } from 'react-icons/fa';
 
 const linkItems = [
   {
@@ -45,9 +52,10 @@ const NavLink: React.FC<NavLinkProps> = ({ link: { name, href } }) => {
 
 const Header = () => {
   const { colorMode, toggleColorMode } = useColorMode();
+  const headerBg = useColorModeValue('gray.100', 'gray.700');
 
   return (
-    <Box bg="gray.100">
+    <Box bg={headerBg}>
       <Flex
         justifyContent="space-between"
         alignItems="center"
@@ -56,16 +64,15 @@ const Header = () => {
         px={4}
       >
         <HStack spacing={8} alignItems="center">
-          <IconButton
-            aria-label="Toggle Dark Mode"
-            icon={colorMode === 'dark' ? <FaSun /> : <FaMoon />}
-            onClick={toggleColorMode}
-          />
           {linkItems.map((link) => (
             <NavLink link={link} key={link.name} />
           ))}
         </HStack>
-        <IconButton aria-label="Menu" icon={<FaBars />} />
+        <IconButton
+          aria-label="Toggle Dark Mode"
+          icon={colorMode === 'dark' ? <FaSun /> : <FaMoon />}
+          onClick={toggleColorMode}
+        />{' '}
       </Flex>
     </Box>
   );

--- a/frontend/src/components/RecipeCard/RecipeCard.tsx
+++ b/frontend/src/components/RecipeCard/RecipeCard.tsx
@@ -1,4 +1,11 @@
-import { Badge, Box, Flex, Heading, Text } from '@chakra-ui/react';
+import {
+  Badge,
+  Box,
+  Flex,
+  Heading,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react';
 
 import type { Recipe } from '@/types';
 
@@ -38,11 +45,12 @@ const RecipeCard: React.FC<Props> = ({ recipe }) => {
 export default RecipeCard;
 
 const CardWrapper: React.FC<CardWrapperProps> = ({ children }) => {
+  const cardBg = useColorModeValue('gray.100', 'gray.700');
   return (
     <Flex
       direction="column"
       justifyContent={'center'}
-      bg="gray.100"
+      bg={cardBg}
       borderRadius="md"
       cursor="pointer"
       boxShadow="base"

--- a/frontend/src/components/SavedRecipeCard.tsx
+++ b/frontend/src/components/SavedRecipeCard.tsx
@@ -1,5 +1,12 @@
 import { useState } from 'react';
-import { Box, Collapse, Flex, Heading, Text } from '@chakra-ui/react';
+import {
+  Box,
+  Collapse,
+  Flex,
+  Heading,
+  Text,
+  useColorModeValue,
+} from '@chakra-ui/react';
 import { StarIcon } from '@chakra-ui/icons';
 
 import type { Recipe } from '@/types';
@@ -13,6 +20,7 @@ type Props = {
 };
 
 const SavedRecipeCard: React.FC<Props> = ({ recipe }) => {
+  const cardBg = useColorModeValue('gray.100', 'gray.700');
   const [showDetails, setShowDetails] = useState(false);
 
   const numberOfIngredients = recipe.ingredients.length;
@@ -20,7 +28,7 @@ const SavedRecipeCard: React.FC<Props> = ({ recipe }) => {
   return (
     <Box
       p={4}
-      bg="gray.100"
+      bg={cardBg}
       marginBottom={4}
       borderRadius="md"
       cursor="pointer"

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,11 +1,24 @@
-import { ChakraProvider } from '@chakra-ui/react';
+import { ChakraProvider, extendTheme } from '@chakra-ui/react';
 import { SessionProvider } from 'next-auth/react';
 import { AppProps } from 'next/app';
+
+const customTheme = extendTheme({
+  config: {
+    initialColorMode: 'light',
+    useSystemColorMode: true,
+  },
+  fonts: {
+    // todo: set the fonts
+    //body: 'YourBodyFont, system-ui, sans-serif',
+    //heading: 'YourHeadingFont, Arial, sans-serif',
+    //mono: 'Menlo, monospace',
+  },
+});
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
     <SessionProvider session={session}>
-      <ChakraProvider>
+      <ChakraProvider theme={customTheme}>
         <Component {...pageProps} />
       </ChakraProvider>
     </SessionProvider>


### PR DESCRIPTION
**Description**:
Adds support for dark mode to the frontend next app - because literally everyone immediately turns that ish to 'dark mode' for a reason. 

**Key Changes**:
- Updates the background for a few containers based on the color mode selection 
  - Both recipe cards 
  - The header 
   
**Next Steps**:
- Add a more cohesive set of colors for the app
- Set new heading and body fonts 
- Fix the hover color on the RecipeCard action buttons 

<img width="1270" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/859d9e58-3b93-4b45-8dc9-28f817cef53a">

<img width="1271" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/502b733d-3c9b-4ef9-bada-17f8a412fb05">

(first card hovered)
<img width="1274" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/e577b4b0-8972-4505-8d40-9196362b088f">

<img width="1268" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/6d38ae2e-0291-4728-ab2a-08b4774bd4c7">
