### PR TITLE
[frontend] feat: new pantry card look

### DIFF
--- a/frontend/src/components/Pantry/Pantry.tsx
+++ b/frontend/src/components/Pantry/Pantry.tsx
@@ -80,7 +80,7 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
       <Toolbar />
       <Grid h="50vh" gridTemplateColumns="1fr 1fr" gap={2}>
         {pantryOrder.map((type) => (
-          <Box key={type} w="100%" cursor="pointer">
+          <Box key={type} w="100%">
             <Flex mb={3}>
               {getIconForType(type)}
               <Heading size="md" ml={2}>

--- a/frontend/src/components/Pantry/PantryItemCard.tsx
+++ b/frontend/src/components/Pantry/PantryItemCard.tsx
@@ -1,6 +1,9 @@
 import {
+  Box,
+  Flex,
   Circle,
   Grid,
+  Icon,
   Slider,
   SliderFilledTrack,
   SliderThumb,
@@ -8,6 +11,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 import { PantryItem } from '@/types';
+import { TbStar, TbGitCommit, TbPencil, TbShoppingCart } from 'react-icons/tb';
 
 type PantryItemCardProps = {
   item: PantryItem;
@@ -15,30 +19,95 @@ type PantryItemCardProps = {
 };
 
 const getStockStatusColor = (quantity: number) => {
-  if (quantity > 0.75) return 'green';
-  if (quantity > 0.25) return 'yellow';
-  return 'red';
+  if (quantity > 0.75) return '#80D39B';
+  if (quantity > 0.25) return '#FFA987';
+  return '#E54B4B';
+};
+
+const IconProps = {
+  boxSize: 6,
+  color: '#FFA987',
+  _hover: {
+    transform: 'scale(1.2)',
+    cursor: 'pointer',
+  },
+  transition: 'all 0.2s ease-in-out',
 };
 
 const PantryItemCard: React.FC<PantryItemCardProps> = ({
   item,
   handleChange,
 }) => {
+  // we'll need a function to get the current amount in stock
+  // based on initialAmount and quantityInStock and the unit of measurement
+  // quantity in stock is a float between 0 and 1
+  // initialAmount is the total amount of the item
+  // so if initialAmount is 2 and quantityInStock is 0.5
+  // we have 1 pound left
+  const amountInStock = '2 pounds';
+
   return (
-    <Grid
+    <Box
+      className="pantry-card__container"
+      bg="#444140"
+      borderRadius="lg"
+      boxShadow="base"
+      p={5}
+      w="full"
       key={item.id}
-      alignContent="center"
-      alignItems="center"
-      gap={1}
-      gridTemplateColumns="min-content 1fr 1fr"
+      position="relative"
+      _hover={{
+        transform: 'scale(1.02)',
+      }}
+      transition="all 0.2s ease-in-out"
     >
-      <Circle
-        size="8px"
-        bg={getStockStatusColor(item.quantityInStock)}
-        mr={2}
+      <Box>
+        <Flex alignItems="center">
+          <Circle size="4" bg={getStockStatusColor(item.quantityInStock)} />
+
+          <Box ml={3}>
+            <Text fontSize="xs" fontStyle="italic">
+              {amountInStock}
+            </Text>
+            <Text fontSize="24px">{item.item}</Text>
+          </Box>
+        </Flex>
+      </Box>
+
+      <Icon
+        as={TbStar}
+        position="absolute"
+        top="12px"
+        right="14px"
+        boxSize="6"
+        color="#FFA987"
       />
-      <Text>{item.item}</Text>
-      <Slider
+
+      <Flex position="absolute" bottom="12px" right="14px" gap={1}>
+        <Icon
+          as={TbGitCommit}
+          transform="rotate(90deg)"
+          boxSize="6"
+          color="#FFA987"
+          _hover={{
+            transform: 'rotate(90deg) scale(1.2)',
+            cursor: 'pointer',
+          }}
+          transition="all 0.2s ease-in-out"
+        />
+        <Icon as={TbPencil} {...IconProps} />
+        <Icon as={TbShoppingCart} {...IconProps} />
+      </Flex>
+    </Box>
+  );
+};
+
+export default PantryItemCard;
+
+// TODO: When an item is favorited, used the filled star icon
+// what happens to favorited items? do they get moved to the top of the list? Do they get alerts when they're low, out of stock?
+/**
+ * <Slider
         aria-label="stock-slider"
         colorScheme="teal"
         defaultValue={item.quantityInStock * 100}
@@ -51,8 +120,4 @@ const PantryItemCard: React.FC<PantryItemCardProps> = ({
         </SliderTrack>
         <SliderThumb />
       </Slider>
-    </Grid>
-  );
-};
-
-export default PantryItemCard;
+ */


### PR DESCRIPTION
More updates to the pantry card 🥳 

Some time was spent drafting out a real design for these cards, this work covers the first part of setting this all up. 

CURRENT:
<img width="551" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/99de251a-386a-411c-b34f-c1ee2de10b38">

- Updates color stock indicator colors
- Updates the layout of the card 
- Adds action icons
- Adds favorite icon 

Design work can be seen in [figma](https://www.figma.com/file/vJFuqS3dlupqMVIhpdEMBS/Untitled?type=design&node-id=0-1&mode=design&t=22riaveFkuCN8CEo-0)

<img width="1452" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/29ba042a-ea7c-4a27-8c20-1ded7061fa3d">
