### PR TITLE
[frontend ]add jotai and atom store 

### DIFF
--- a/frontend/lib/store/pantry.store.ts
+++ b/frontend/lib/store/pantry.store.ts
@@ -1,0 +1,11 @@
+import { atom } from 'jotai';
+
+// If value is { id: 3, content: 'FORM' },
+// it means the drawer for card with id=3 is open, and it should show the form content.
+// A value of null means no card's drawer is open.
+// this will ensure only one drawer is open at a time and the database is only updated when the drawer is closed
+// might want to rethink some of the UI/UX here - how will they know changes will be saved when they close the drawer?
+export const activeCardDrawerAtom = atom<{
+  id: number;
+  content: 'SLIDER' | 'FORM';
+} | null>(null);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "eslint": "8.47.0",
     "eslint-config-next": "13.4.13",
     "framer-motion": "^10.15.1",
+    "jotai": "^2.4.2",
     "next": "13.4.13",
     "next-auth": "^4.23.0",
     "react": "18.2.0",

--- a/frontend/src/pages/_app.tsx
+++ b/frontend/src/pages/_app.tsx
@@ -1,14 +1,17 @@
 import { ChakraProvider } from '@chakra-ui/react';
 import { SessionProvider } from 'next-auth/react';
+import { Provider as AtomProvider } from 'jotai';
 import { AppProps } from 'next/app';
 import customTheme from '@/styles/theme';
 
 function MyApp({ Component, pageProps: { session, ...pageProps } }: AppProps) {
   return (
     <SessionProvider session={session}>
-      <ChakraProvider theme={customTheme}>
-        <Component {...pageProps} />
-      </ChakraProvider>
+      <AtomProvider>
+        <ChakraProvider theme={customTheme}>
+          <Component {...pageProps} />
+        </ChakraProvider>
+      </AtomProvider>
     </SessionProvider>
   );
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2776,6 +2776,11 @@ jose@^4.11.4, jose@^4.14.4:
   resolved "https://registry.yarnpkg.com/jose/-/jose-4.14.4.tgz#59e09204e2670c3164ee24cbfe7115c6f8bff9ca"
   integrity sha512-j8GhLiKmUAh+dsFXlX1aJCbt5KMibuKb+d7j1JaOJG6s2UjX1PQlW+OKB/sD4a/5ZYF4RcmYmLSndOoU3Lt/3g==
 
+jotai@^2.4.2:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/jotai/-/jotai-2.4.2.tgz#85610d82d247a7b19de7cce82e8d3ddf007f8d4d"
+  integrity sha512-90jXVOd9h6gi5JXk558M+wnJfaaVN2WegcNOCfiFbWboNaDl6DkRgiY/K1oeqTfYJmq8yM7XPsL99LAvcOPqhw==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
### Pull Request: Addition of Jotai for State Management and `activeCardDrawerAtom` Implementation

#### **Overview:**

PR introduces Jotai for fine-grained, atom-based state management. As part of the first step in this integration, we're also rolling out our very first atom: `activeCardDrawerAtom`.

#### **Changes:**

1. **Installation of Jotai:** 
   - Jotai has been added as a dependency.
   - Basic configuration and integration into app's root component have been completed.

2. **Implementation of `activeCardDrawerAtom`:**
   - This atom helps in keeping track of the active card drawer's ID and the type of content it should display (either the SLIDER or the FORM).
   - It's designed to offer a single source of truth for which card's drawer is currently active, ensuring that only one card can have its drawer open at a given time.

#### **Why Jotai?**

1. **Fine-grained State Management:** Instead of having large chunks of state Jotai promotes atom-based state where each atom can represent a small piece of state. This makes it easier to manage and update state in response to user actions or other events.
  
2. **Derived State:** Jotai offers powerful tools to derive state from other atoms. This means less manual state manipulation and more reactivity built right in.
  
3. **Performance:** Only components that use specific atoms will re-render when those atoms change. This reduces unnecessary renders and can lead to performance improvements.
  
4. **Simplicity and Flexibility:** t integrates well with React's hooks-based architecture.
