### PR TITLE
[frontend] feat: edit item form

### DIFF
--- a/frontend/src/components/PantryCard/PantryCard.tsx
+++ b/frontend/src/components/PantryCard/PantryCard.tsx
@@ -34,7 +34,7 @@ const PantryCard: React.FC<PantryCardProps> = ({ item }) => {
           transform: 'scale(1.02)',
         }}
         transition="all 0.2s ease-in-out"
-        zIndex={1}
+        zIndex={2}
       >
         <ItemDetail {...item} />
         <Icon

--- a/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
+++ b/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
@@ -22,8 +22,8 @@ const drawerVariants = {
     y: 0,
     transition: { type: 'spring', stiffness: 100, damping: 15 },
   },
-  closed: { opacity: 0, y: '-100%' },
-  exit: { opacity: 0, y: '-100%', transition: { duration: 0.2 } },
+  closed: { opacity: 0, y: '-50%' },
+  exit: { opacity: 0, y: '-50%', transition: { duration: 0.2 } },
 };
 
 const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {

--- a/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
+++ b/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
@@ -39,7 +39,7 @@ const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {
           mx="auto"
           bg="atomicTangerine"
           borderBottomRadius="lg"
-          zIndex={0}
+          zIndex={1}
           mt="-3"
           initial="closed"
           animate={show ? 'open' : 'closed'}
@@ -49,7 +49,7 @@ const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {
           {activeCardDrawer?.content === 'SLIDER' ? (
             <StockSlider {...item} />
           ) : (
-            <EditItemForm />
+            <EditItemForm {...item} />
           )}
         </MotionBox>
       )}

--- a/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
+++ b/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
@@ -2,10 +2,11 @@ import React from 'react';
 import { useAtomValue } from 'jotai';
 import { Box, Center, Text } from '@chakra-ui/react';
 import { AnimatePresence, motion } from 'framer-motion';
-
-import StockSlider from './StockSlider';
 import { activeCardDrawerAtom } from '@/lib/store/pantry.store';
 import type { PantryItem } from '@/types';
+
+import StockSlider from './StockSlider';
+import { EditItemForm } from '@/components/forms';
 
 const MotionBox = motion(Box);
 
@@ -34,7 +35,7 @@ const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {
     <AnimatePresence>
       {show && (
         <MotionBox
-          w="96%"
+          w="98.5%"
           mx="auto"
           bg="atomicTangerine"
           borderBottomRadius="lg"
@@ -42,15 +43,13 @@ const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {
           mt="-3"
           initial="closed"
           animate={show ? 'open' : 'closed'}
-          exit="exit"
+          //exit="exit"
           variants={drawerVariants}
         >
           {activeCardDrawer?.content === 'SLIDER' ? (
             <StockSlider {...item} />
           ) : (
-            <Center h="100%">
-              <Text>Form</Text>
-            </Center>
+            <EditItemForm />
           )}
         </MotionBox>
       )}

--- a/frontend/src/components/RecipeCard/controls/ActionButtonSet.tsx
+++ b/frontend/src/components/RecipeCard/controls/ActionButtonSet.tsx
@@ -13,9 +13,7 @@ const ActionButtonSet: React.FC = () => {
       top="20px"
       right="20px"
       gap={2}
-      zIndex={3}
-      display="none" // Initially hide
-      className="action-buttons" // Used to show on hover of CardWrapper
+      className="pantry-card__action-buttons"
     >
       <IconButton {...buttonStyles} icon={<AddIcon />} aria-label="Add" />
       <IconButton

--- a/frontend/src/components/forms/AddItemForm.pantry.tsx
+++ b/frontend/src/components/forms/AddItemForm.pantry.tsx
@@ -14,6 +14,8 @@ import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
 
 import { Select } from '@/components/inputs/';
 
+// TODO: add an option to add the item to shopping list upon creation
+// TODO: close the active drawer when this form opens, to prevent any weird hits to the db
 const foodTypeOptions = [
   { value: 'dairy', label: 'Dairy', icon: <TbMilk /> },
   { value: 'produce', label: 'Produce', icon: <TbApple /> },

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -4,33 +4,22 @@ import { PantryItem, pantryItemUnits } from '@/types';
 
 import { TwoPointNumberInput, Select } from '@/components/inputs';
 
-/**
- * type SelectProps = {
-  options: {
-    value: string;
-    label: string;
-    icon?: any;
-    isDisabled?: boolean;
-  }[];
-  value: string;
-  onChange: (value: string) => void;
-};
- */
-
 const EditItemForm = (item: PantryItem): JSX.Element => {
   const {
     initialAmount: itemInitialAmount,
     unit: itemUnit,
     cost: itemCost,
   } = item;
-  const [initialAmount, setInitialAmount] = React.useState(itemInitialAmount);
-  const [cost, setCost] = React.useState(itemCost);
+  const [initialAmount, setInitialAmount] = React.useState(
+    String(itemInitialAmount)
+  );
+  const [cost, setCost] = React.useState(String(itemCost));
   const [unit, setUnit] = React.useState(itemUnit);
 
   const itemType = item.type;
   const unitTypeOptions = pantryItemUnits[itemType];
+
   // we've set up the units object, but we need to create actual options
-  // we'll use a memo
   // and map current options to the right shape
   const unitOptions = React.useMemo(() => {
     return unitTypeOptions.map((unit) => ({
@@ -39,10 +28,10 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
     }));
   }, [unitTypeOptions]);
 
+  // const [currency, setCurrency] = React.useState('USD');
   // I don't think I'll provide a way to change currency here
   // the user should set it as a profile option
   // i see little reason to track different currencies in the same pantry
-  // const [currency, setCurrency] = React.useState('USD');
   // I do need to provide a way to change the unit
   // Because a user might have bought a 2L bottle of milk instead of a 1L bottle
   // but we can still prompt the user for some guidance on how to handle this
@@ -60,7 +49,7 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
       onSubmit={handleSubmit}
       maxWidth="400px"
       margin="0 auto"
-      px={2}
+      px={1}
       py={4}
     >
       <FormControl
@@ -84,6 +73,7 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
       <FormControl mb={4}>
         {/* <FormLabel>Cost</FormLabel> */}
         <TwoPointNumberInput
+          format="$"
           value={cost}
           onChange={(value) => setCost(value)}
         />
@@ -97,48 +87,3 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
 };
 
 export default EditItemForm;
-
-/**
- *   const [currentArea, setCurrentArea] = useState(fixedInitialArea)
-  const fixedInitialArea = area.toFixed(2)
-// dynamic step for the number input
-export const getStep = (area: string) => {
-  // convert to number for comparisons
-  const parsedArea = parseInt(area)
-  if (parsedArea < 50) return 1.0
-  if (parsedArea < 200) return 5.0
-  return 10.0
-}
-  const fixedInitialArea = area.toFixed(2)
-
-
-export const inputProps = {
-  bg: "white",
-  border: "3px dashed",
-  borderRadius: "md",
-  borderColor: "gray.300",
-  color: "gray.400",
-  fontSize: "md",
-  fontFamily: "body",
-  _hover: { borderColor: "gray.400" },
-  _focusVisible: { borderColor: "gray.400" },
-}
- * 
- * <NumberInput
-            {...inputProps}
-            onChange={value => setCurrentArea(value)}
-            defaultValue={fixedInitialArea}
-            value={currentArea}
-            precision={2}
-            step={getStep(currentArea)}
-            min={0.0}
-            focusBorderColor="transparent"
-            size="sm"
-          >
-            <NumberInputField border="none" />
-            <NumberInputStepper>
-              <NumberIncrementStepper border="none" />
-              <NumberDecrementStepper border="none" />
-            </NumberInputStepper>
-          </NumberInput>
- */

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Select } from '@/components/inputs';
+import { Box, Text } from '@chakra-ui/react';
+
+const EditItemForm = () => {
+  return (
+    <Box>
+      <Text>Form</Text>
+    </Box>
+  );
+};
+
+export default EditItemForm;

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -1,13 +1,127 @@
 import React from 'react';
 import { Select } from '@/components/inputs';
-import { Box, Text } from '@chakra-ui/react';
+import {
+  Box,
+  FormControl,
+  FormLabel,
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  Button,
+} from '@chakra-ui/react';
+import { PantryItem } from '@/types';
 
 const EditItemForm = () => {
+  const [initialAmount, setInitialAmount] = React.useState('0.00');
+  const [cost, setCost] = React.useState(0);
+  const [currency, setCurrency] = React.useState('USD');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    // Handle form submission here
+    console.log(
+      'Initial Amount:',
+      initialAmount,
+      'Cost:',
+      cost,
+      'Currency:',
+      currency
+    );
+  };
+
   return (
-    <Box>
-      <Text>Form</Text>
+    <Box as="form" onSubmit={handleSubmit} maxWidth="400px" margin="0 auto">
+      <FormControl mb={4}>
+        <FormLabel>Weight (volume)</FormLabel>
+        <NumberInput
+          defaultValue={initialAmount}
+          onChange={(value) => setInitialAmount(value)}
+          value={initialAmount}
+          precision={2}
+          step={1.0}
+          min={0.0}
+        >
+          <NumberInputField />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+        </NumberInput>
+      </FormControl>
+
+      <FormControl mb={4}>
+        <FormLabel>Cost</FormLabel>
+        <NumberInput
+          min={0}
+          precision={2}
+          step={0.01}
+          value={cost}
+          onChange={(valueString) => setCost(parseFloat(valueString))}
+        >
+          <NumberInputField placeholder="Enter cost" />
+          <NumberInputStepper>
+            <NumberIncrementStepper />
+            <NumberDecrementStepper />
+          </NumberInputStepper>
+        </NumberInput>
+      </FormControl>
+
+      <FormControl mb={4}>
+        <FormLabel>Currency</FormLabel>
+      </FormControl>
+
+      <Button type="submit" colorScheme="teal">
+        Submit
+      </Button>
     </Box>
   );
 };
 
 export default EditItemForm;
+
+/**
+ *   const [currentArea, setCurrentArea] = useState(fixedInitialArea)
+  const fixedInitialArea = area.toFixed(2)
+// dynamic step for the number input
+export const getStep = (area: string) => {
+  // convert to number for comparisons
+  const parsedArea = parseInt(area)
+  if (parsedArea < 50) return 1.0
+  if (parsedArea < 200) return 5.0
+  return 10.0
+}
+  const fixedInitialArea = area.toFixed(2)
+
+
+export const inputProps = {
+  bg: "white",
+  border: "3px dashed",
+  borderRadius: "md",
+  borderColor: "gray.300",
+  color: "gray.400",
+  fontSize: "md",
+  fontFamily: "body",
+  _hover: { borderColor: "gray.400" },
+  _focusVisible: { borderColor: "gray.400" },
+}
+ * 
+ * <NumberInput
+            {...inputProps}
+            onChange={value => setCurrentArea(value)}
+            defaultValue={fixedInitialArea}
+            value={currentArea}
+            precision={2}
+            step={getStep(currentArea)}
+            min={0.0}
+            focusBorderColor="transparent"
+            size="sm"
+          >
+            <NumberInputField border="none" />
+            <NumberInputStepper>
+              <NumberIncrementStepper border="none" />
+              <NumberDecrementStepper border="none" />
+            </NumberInputStepper>
+          </NumberInput>
+ */

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -1,78 +1,95 @@
 import React from 'react';
-import { Select } from '@/components/inputs';
-import {
-  Box,
-  FormControl,
-  FormLabel,
-  NumberInput,
-  NumberInputField,
-  NumberInputStepper,
-  NumberIncrementStepper,
-  NumberDecrementStepper,
-  Button,
-} from '@chakra-ui/react';
-import { PantryItem } from '@/types';
+import { Box, FormControl, FormLabel, Button } from '@chakra-ui/react';
+import { PantryItem, pantryItemUnits } from '@/types';
 
-const EditItemForm = () => {
-  const [initialAmount, setInitialAmount] = React.useState('0.00');
-  const [cost, setCost] = React.useState(0);
-  const [currency, setCurrency] = React.useState('USD');
+import { TwoPointNumberInput, Select } from '@/components/inputs';
+
+/**
+ * type SelectProps = {
+  options: {
+    value: string;
+    label: string;
+    icon?: any;
+    isDisabled?: boolean;
+  }[];
+  value: string;
+  onChange: (value: string) => void;
+};
+ */
+
+const EditItemForm = (item: PantryItem): JSX.Element => {
+  const {
+    initialAmount: itemInitialAmount,
+    unit: itemUnit,
+    cost: itemCost,
+  } = item;
+  const [initialAmount, setInitialAmount] = React.useState(itemInitialAmount);
+  const [cost, setCost] = React.useState(itemCost);
+  const [unit, setUnit] = React.useState(itemUnit);
+
+  const itemType = item.type;
+  const unitTypeOptions = pantryItemUnits[itemType];
+  // we've set up the units object, but we need to create actual options
+  // we'll use a memo
+  // and map current options to the right shape
+  const unitOptions = React.useMemo(() => {
+    return unitTypeOptions.map((unit) => ({
+      value: unit,
+      label: unit,
+    }));
+  }, [unitTypeOptions]);
+
+  // I don't think I'll provide a way to change currency here
+  // the user should set it as a profile option
+  // i see little reason to track different currencies in the same pantry
+  // const [currency, setCurrency] = React.useState('USD');
+  // I do need to provide a way to change the unit
+  // Because a user might have bought a 2L bottle of milk instead of a 1L bottle
+  // but we can still prompt the user for some guidance on how to handle this
+  // ask for metric or imperial at sign up
 
   const handleSubmit = (e) => {
     e.preventDefault();
     // Handle form submission here
-    console.log(
-      'Initial Amount:',
-      initialAmount,
-      'Cost:',
-      cost,
-      'Currency:',
-      currency
-    );
+    console.log('Initial Amount:', initialAmount, 'Cost:', cost);
   };
 
   return (
-    <Box as="form" onSubmit={handleSubmit} maxWidth="400px" margin="0 auto">
-      <FormControl mb={4}>
-        <FormLabel>Weight (volume)</FormLabel>
-        <NumberInput
-          defaultValue={initialAmount}
-          onChange={(value) => setInitialAmount(value)}
+    <Box
+      as="form"
+      onSubmit={handleSubmit}
+      maxWidth="400px"
+      margin="0 auto"
+      px={2}
+      py={4}
+    >
+      <FormControl
+        mb={4}
+        display="grid"
+        gridTemplateColumns={'2fr 1fr'}
+        gap="2"
+      >
+        {/* <FormLabel>Weight (volume)</FormLabel> */}
+        <TwoPointNumberInput
           value={initialAmount}
-          precision={2}
-          step={1.0}
-          min={0.0}
-        >
-          <NumberInputField />
-          <NumberInputStepper>
-            <NumberIncrementStepper />
-            <NumberDecrementStepper />
-          </NumberInputStepper>
-        </NumberInput>
+          onChange={(value) => setInitialAmount(value)}
+        />
+        <Select
+          options={unitOptions}
+          value={unit}
+          onChange={(value) => setUnit(value)}
+        />
       </FormControl>
 
       <FormControl mb={4}>
-        <FormLabel>Cost</FormLabel>
-        <NumberInput
-          min={0}
-          precision={2}
-          step={0.01}
+        {/* <FormLabel>Cost</FormLabel> */}
+        <TwoPointNumberInput
           value={cost}
-          onChange={(valueString) => setCost(parseFloat(valueString))}
-        >
-          <NumberInputField placeholder="Enter cost" />
-          <NumberInputStepper>
-            <NumberIncrementStepper />
-            <NumberDecrementStepper />
-          </NumberInputStepper>
-        </NumberInput>
+          onChange={(value) => setCost(value)}
+        />
       </FormControl>
 
-      <FormControl mb={4}>
-        <FormLabel>Currency</FormLabel>
-      </FormControl>
-
-      <Button type="submit" colorScheme="teal">
+      <Button type="submit" bg="imperialRed" w="full">
         Submit
       </Button>
     </Box>

--- a/frontend/src/components/forms/index.ts
+++ b/frontend/src/components/forms/index.ts
@@ -1,0 +1,2 @@
+export { default as AddItemForm } from './AddItemForm.pantry';
+export { default as EditItemForm } from './EditItemForm.pantry';

--- a/frontend/src/components/inputs/TwoPointNumberInput.tsx
+++ b/frontend/src/components/inputs/TwoPointNumberInput.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import {
+  NumberInput,
+  NumberInputField,
+  NumberInputStepper,
+  NumberIncrementStepper,
+  NumberDecrementStepper,
+  Button,
+} from '@chakra-ui/react';
+
+// created this as a component because I'll probably use this in a lot of places
+// adding recipes
+// updating pantry items
+// adding items to shopping list
+// etc.
+
+// if for some reason I need to have a number input for a different precision
+// then I'll update this to be 'FloatingPointNumberInput' or something
+// and add precision to props
+
+type TwoPointNumberInputProps = {
+  defaultValue?: string; // if not passed, we assume the same as value
+  onChange: (value: string) => void;
+  value: string;
+};
+
+const TwoPointNumberInput: React.FC<TwoPointNumberInputProps> = ({
+  defaultValue,
+  value,
+  onChange,
+}) => {
+  // variable to determine default value
+  const initialAmount = defaultValue ? defaultValue : value;
+
+  return (
+    <NumberInput
+      defaultValue={initialAmount}
+      onChange={(value) => onChange(value)}
+      value={value}
+      precision={2}
+      step={1.0}
+      min={0.0}
+    >
+      <NumberInputField />
+      <NumberInputStepper>
+        <NumberIncrementStepper />
+        <NumberDecrementStepper />
+      </NumberInputStepper>
+    </NumberInput>
+  );
+};
+
+export default TwoPointNumberInput;

--- a/frontend/src/components/inputs/TwoPointNumberInput.tsx
+++ b/frontend/src/components/inputs/TwoPointNumberInput.tsx
@@ -17,6 +17,17 @@ import {
 // if for some reason I need to have a number input for a different precision
 // then I'll update this to be 'FloatingPointNumberInput' or something
 // and add precision to props
+export const inputProps = {
+  bg: 'white',
+  border: '3px dashed',
+  borderRadius: 'md',
+  borderColor: 'gray.300',
+  color: 'gray.400',
+  fontSize: 'md',
+  fontFamily: 'body',
+  _hover: { borderColor: 'gray.400' },
+  _focusVisible: { borderColor: 'gray.400' },
+};
 
 type TwoPointNumberInputProps = {
   defaultValue?: string; // if not passed, we assume the same as value
@@ -24,11 +35,11 @@ type TwoPointNumberInputProps = {
   value: string;
 };
 
-const TwoPointNumberInput: React.FC<TwoPointNumberInputProps> = ({
+const TwoPointNumberInput = ({
   defaultValue,
   value,
   onChange,
-}) => {
+}: TwoPointNumberInputProps): JSX.Element => {
   // variable to determine default value
   const initialAmount = defaultValue ? defaultValue : value;
 
@@ -41,7 +52,7 @@ const TwoPointNumberInput: React.FC<TwoPointNumberInputProps> = ({
       step={1.0}
       min={0.0}
     >
-      <NumberInputField />
+      <NumberInputField bg="jet" />
       <NumberInputStepper>
         <NumberIncrementStepper />
         <NumberDecrementStepper />

--- a/frontend/src/components/inputs/TwoPointNumberInput.tsx
+++ b/frontend/src/components/inputs/TwoPointNumberInput.tsx
@@ -17,37 +17,32 @@ import {
 // if for some reason I need to have a number input for a different precision
 // then I'll update this to be 'FloatingPointNumberInput' or something
 // and add precision to props
-export const inputProps = {
-  bg: 'white',
-  border: '3px dashed',
-  borderRadius: 'md',
-  borderColor: 'gray.300',
-  color: 'gray.400',
-  fontSize: 'md',
-  fontFamily: 'body',
-  _hover: { borderColor: 'gray.400' },
-  _focusVisible: { borderColor: 'gray.400' },
-};
 
 type TwoPointNumberInputProps = {
   defaultValue?: string; // if not passed, we assume the same as value
   onChange: (value: string) => void;
   value: string;
+  format?: string;
 };
 
 const TwoPointNumberInput = ({
   defaultValue,
   value,
   onChange,
+  format,
 }: TwoPointNumberInputProps): JSX.Element => {
-  // variable to determine default value
   const initialAmount = defaultValue ? defaultValue : value;
+
+  // If a format is passed it will be prepended to the value
+  // Mostly for currency symbols
+  const formatValue = (val: string) => format + val;
+  const formatedValue = format ? formatValue(value) : value;
 
   return (
     <NumberInput
       defaultValue={initialAmount}
       onChange={(value) => onChange(value)}
-      value={value}
+      value={formatedValue}
       precision={2}
       step={1.0}
       min={0.0}

--- a/frontend/src/components/inputs/index.tsx
+++ b/frontend/src/components/inputs/index.tsx
@@ -1,1 +1,2 @@
 export { default as Select } from './Select';
+export { default as TwoPointNumberInput } from './TwoPointNumberInput';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,4 @@
+// cheatsheets: https://github.com/typescript-cheatsheets/react#reacttypescript-cheatsheets
 // all of the props here should also be in the Recipe type
 // we just want to render more of them here, but both components are using the same type, the same data
 // let's think about ingredients - this should be a type of its own
@@ -60,4 +61,26 @@ export type PantryItem = {
   type: 'dairy' | 'produce' | 'pantry' | 'staple' | 'frozen';
   cost: number;
   costUnit: string;
+};
+
+/** Objects to support unit measurements - applies largely to Pantry items  */
+// TODO: Identify if this should go here? It's note really a type
+const commonUnits = ['pound', 'ounce', 'kilogram', 'gram', 'unit'];
+const dairyUnits = [
+  'gallon',
+  'quart',
+  'pint',
+  'cup',
+  'stick',
+  'tablespoon',
+  'teaspoon',
+  'slice',
+];
+
+export const pantryItemUnits = {
+  dairy: [...dairyUnits, ...commonUnits],
+  produce: [...commonUnits],
+  pantry: [...commonUnits],
+  staple: [...commonUnits],
+  frozen: [...commonUnits],
 };


### PR DESCRIPTION
### PR Title: 
**Enhancement: Unit System and Editable Fields in PantryCardDrawer**

### PR Description:

**What's Added**:
1. **`pantryItemUnits`**: Introduced a versatile unit system allowing users to track quantities in various units including pounds, grams, slices, and more.
2. **`TwoPointNumberInput`**: A new reusable input component is added which restricts input to two decimal points. This not only enhances precision but also offers basic formatting.
3. **EditItemForm in PantryCardDrawer**: Implemented an editing interface within the `PantryCardDrawer`. This allows users to update the item amount, unit, and cost directly from the drawer.

![Pantry Card Drawer with Edit Item Form](https://github.com/ash-bergs/dish-dollar/assets/65979049/bac4669d-5669-4f40-9f2c-c706fe4dc22d)

**Future Considerations**:
- **Unified Input Appearance**: Plan to standardize the look and feel across all input components. I'll most likely create a dedicated styles directory within the inputs folder for shared styles. Once established, these styles can potentially be integrated into our theme.
  
- **Select Z-Index Challenge in PantryCardDrawer**: Currently, the `Select` dropdown in the drawer is layered below other cards due to its nested context. This design aspect requires reconsideration. One potential solution could involve elevating the Z-index of the currently active card, positioning it above neighboring cards. If this proves challenging, a design revisit might be necessary to ensure the drawer aesthetically layers beneath its card.

-**Remove Items from Pantry**: The card needs a delete icon somwhere - this could potentially clutter the actions area - consider placing somewhere else on the card?

---