### PR TITLE
[frontend] feat: primary button variant

### DIFF
--- a/frontend/src/components/Pantry/Pantry.tsx
+++ b/frontend/src/components/Pantry/Pantry.tsx
@@ -1,5 +1,14 @@
 import React, { useState } from 'react';
-import { Box, Flex, Grid, VStack, Heading } from '@chakra-ui/react';
+import {
+  Box,
+  Flex,
+  Grid,
+  Icon,
+  VStack,
+  Heading,
+  IconProps,
+  useColorMode,
+} from '@chakra-ui/react';
 import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
 /** component imports */
 import Toolbar from './Toolbar';
@@ -22,19 +31,24 @@ type PantryProps = {
   pantryItems: PantryItem[];
 };
 
+const iconProps: IconProps = {
+  boxSize: '7',
+  textShadow: 'lg',
+};
+
 // utility to map icons
 const getIconForType = (type: PantryItem['type']) => {
   switch (type) {
     case 'dairy':
-      return <TbMilk />;
+      return <Icon as={TbMilk} {...iconProps} />;
     case 'produce':
-      return <TbApple />;
+      return <Icon as={TbApple} {...iconProps} />;
     case 'pantry':
-      return <TbFridge />;
+      return <Icon as={TbFridge} {...iconProps} />;
     case 'staple':
-      return <TbPin />;
+      return <Icon as={TbPin} {...iconProps} />;
     case 'frozen':
-      return <TbIceCream />;
+      return <Icon as={TbIceCream} {...iconProps} />;
     default:
       return null;
   }
@@ -81,9 +95,15 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
       <Grid h="50vh" gridTemplateColumns="1fr 1fr" gap={6}>
         {pantryOrder.map((type) => (
           <Box key={type} w="100%">
-            <Flex mb={3}>
+            <Flex mb={3} alignContent={'center'} alignItems={'center'}>
               {getIconForType(type)}
-              <Heading size="md" ml={2}>
+              <Heading
+                as="h3"
+                fontWeight="700"
+                fontSize="24"
+                ml={1}
+                textShadow="lg"
+              >
                 {type}
               </Heading>
             </Flex>

--- a/frontend/src/components/Pantry/Toolbar.tsx
+++ b/frontend/src/components/Pantry/Toolbar.tsx
@@ -1,5 +1,5 @@
 import {
-  Box,
+  Flex,
   Button,
   Menu,
   MenuButton,
@@ -9,17 +9,21 @@ import {
   InputGroup,
   InputRightElement,
   Icon,
+  useColorMode,
 } from '@chakra-ui/react';
 import { ChevronDownIcon, SearchIcon } from '@chakra-ui/icons';
 import AddItemForm from '~/components/forms/AddItemForm.pantry';
+import inputStyles from '~/components/inputs/styles';
 
 function Toolbar() {
+  const { colorMode } = useColorMode();
+  const styles = inputStyles(colorMode);
   return (
-    <Box
+    <Flex
       p={4}
-      display="flex"
       justifyContent="space-between"
       alignItems="center"
+      gap={2}
       //boxShadow="base"
       //bg="white"
     >
@@ -38,12 +42,12 @@ function Toolbar() {
       <AddItemForm />
       {/* Search input */}
       <InputGroup>
-        <Input placeholder="Search by text..." />
+        <Input {...styles} placeholder="Search by text..." />
         <InputRightElement>
           <Icon as={SearchIcon} />
         </InputRightElement>
       </InputGroup>
-    </Box>
+    </Flex>
   );
 }
 

--- a/frontend/src/components/forms/AddItemForm.pantry.tsx
+++ b/frontend/src/components/forms/AddItemForm.pantry.tsx
@@ -11,7 +11,7 @@ import {
 } from '@chakra-ui/react';
 import { useDisclosure } from '@chakra-ui/react';
 import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
-
+import { ArrowForwardIcon } from '@chakra-ui/icons';
 import { Select } from '~/components/inputs/';
 
 // TODO: add an option to add the item to shopping list upon creation
@@ -52,7 +52,13 @@ const AddItemForm: React.FC = () => {
 
   return (
     <>
-      {!isOpen && <Button onClick={onOpen}>Add an item</Button>}
+      <Button
+        variant="primary"
+        onClick={onOpen}
+        rightIcon={<ArrowForwardIcon />}
+      >
+        Add an item
+      </Button>
 
       <Modal isOpen={isOpen} onClose={onClose}>
         <ModalOverlay />
@@ -98,7 +104,9 @@ const AddItemForm: React.FC = () => {
               />
             </Grid>
             <Flex gap={4}>
-              <Button onClick={handleAddItem}>Submit</Button>
+              <Button variant="primary" onClick={handleAddItem}>
+                Submit
+              </Button>
               <Button onClick={onClose}>Cancel</Button>
             </Flex>
           </VStack>

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -70,7 +70,7 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
         />
       </FormControl>
 
-      <Button type="submit" bg="imperialRed" w="full">
+      <Button type="submit" variant="primary" w="full">
         Submit
       </Button>
     </Box>

--- a/frontend/src/components/inputs/styles.tsx
+++ b/frontend/src/components/inputs/styles.tsx
@@ -7,7 +7,7 @@ import { ColorMode } from '@chakra-ui/react';
  * This utility provides styles for special cases where the theme doesn't apply.
  */
 const inputStyles = (colorMode: ColorMode) => ({
-  bg: mode('gray.100', 'jet')({ colorMode }),
+  bg: mode('white', 'jet')({ colorMode }),
   color: mode('jet', 'white')({ colorMode }),
   borderRadius: 'md',
 });

--- a/frontend/src/components/pages/recipes/Header.tsx
+++ b/frontend/src/components/pages/recipes/Header.tsx
@@ -1,20 +1,22 @@
-import React from "react";
-import { Button, Center, Flex, Grid, Heading, Text } from "@chakra-ui/react";
+import React from 'react';
+import { Button, Center, Flex, Grid, Heading, Text } from '@chakra-ui/react';
 
 //TODO: how to present user's recipes? Create a recipe box icon, animate it flipping open, and then show the recipes in a grid?
 // Draft this in figma before building
 // TODO: New recipes button has a ! icon when there are new recipes to view
 export const Header = () => {
   return (
-    <Grid gridTemplateColumns={"1fr auto"}>
+    <Grid gridTemplateColumns={'1fr auto'}>
       <Heading>Recipes</Heading>
       <Center>
-        <Flex gap={2} alignItems={"center"}>
-        <Text fontSize="xs">Your Recipes</Text>
-        <Text fontSize="xs">New Recipes</Text>
-        <Button>Add Recipe</Button>
+        <Flex gap={2} alignItems={'center'}>
+          <Text fontSize="xs">Your Recipes</Text>
+          <Text fontSize="xs">New Recipes</Text>
+          <Button variant="primary" px={4}>
+            Add Recipe
+          </Button>
         </Flex>
-      </Center> 
+      </Center>
     </Grid>
   );
 };

--- a/frontend/src/pages/_document.tsx
+++ b/frontend/src/pages/_document.tsx
@@ -1,0 +1,37 @@
+import { ColorModeScript } from '@chakra-ui/react';
+import Document, { Html, Head, Main, NextScript } from 'next/document';
+
+class MyDocument extends Document {
+  static async getInitialProps(ctx: any) {
+    const initialProps = await Document.getInitialProps(ctx);
+    return { ...initialProps };
+  }
+
+  render() {
+    return (
+      <Html lang="en">
+        <Head>
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Onest:wght@300;400;500;600;700&display=swap"
+            rel="stylesheet"
+          />
+          <link rel="preconnect" href="https://fonts.googleapis.com" />
+          <link rel="preconnect" href="https://fonts.gstatic.com" />
+          <link
+            href="https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;1,300;1,400;1,500&display=swap"
+            rel="stylesheet"
+          />
+        </Head>
+        <body>
+          <ColorModeScript />
+          <Main />
+          <NextScript />
+        </body>
+      </Html>
+    );
+  }
+}
+
+export default MyDocument;

--- a/frontend/src/pages/pantry.tsx
+++ b/frontend/src/pages/pantry.tsx
@@ -6,13 +6,6 @@ import { trpc } from '~/utils/trpc';
 
 //TODO: move Pantry to /page directory -> rename to PantryView
 export default function Home() {
-  const utils = trpc.useContext();
-  console.log('utils', utils);
-
-  const allIngredientData = utils.test.allIngredients.getData();
-
-  console.log('allIngredientData', allIngredientData);
-
   return (
     <Layout>
       <Pantry pantryItems={pantryItems} />

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -13,12 +13,38 @@ const styles = {
   }),
 };
 
+// button variants - needs its own module
+const buttonVariants = {
+  primary: {
+    bg: 'linear-gradient(to bottom, #FFA987, #E54B4B)',
+    borderRadius: 'md',
+    boxShadow: 'md',
+    color: 'white',
+    _hover: {
+      bg: 'linear-gradient(to bottom, #FFB387, #F75151)', // hue shift on tangerine, brightness increase on imperial red
+      boxShadow: 'lg',
+      transform: 'scale(1.02)',
+    },
+    px: '8',
+    transition: 'all .3s',
+  },
+};
+
 const config = {
   initialColorMode: 'light',
   useSystemColorMode: true,
 };
 
 const customTheme = extendTheme({
+  fonts: {
+    body: 'Open Sans, sans-serif',
+    heading: 'Onest, sans-serif',
+  },
+  components: {
+    Button: {
+      variants: buttonVariants,
+    },
+  },
   config,
   styles,
   colors,


### PR DESCRIPTION
Adds first button variant - 'primary' 

This button has a gradient using the tangerine and red colors selected for the theme. Lightens and scales up by .02 on hover. 

<img width="880" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/c2cebe5a-7299-4769-9f24-00d309ea22b4">

For right now I just have the button variants defined in the `theme` itself, but the next PR will introduce the 'secondary' button variant and I'll create a new file then. 

After creating the variant it was applied to a couple other buttons around the app. 

The headings still need some love - not quite sure how to improve them yet, 