### PR TITLE
[frontend] feat: secondary button variant

### DIFF
--- a/frontend/src/components/forms/AddItemForm.pantry.tsx
+++ b/frontend/src/components/forms/AddItemForm.pantry.tsx
@@ -107,7 +107,9 @@ const AddItemForm: React.FC = () => {
               <Button variant="primary" onClick={handleAddItem}>
                 Submit
               </Button>
-              <Button onClick={onClose}>Cancel</Button>
+              <Button variant="secondary" onClick={onClose}>
+                Cancel
+              </Button>
             </Flex>
           </VStack>
         </ModalContent>

--- a/frontend/src/styles/buttonVariants.ts
+++ b/frontend/src/styles/buttonVariants.ts
@@ -1,0 +1,32 @@
+// button variants - needs its own module
+const buttonVariants = {
+  primary: {
+    bg: 'linear-gradient(to bottom, #FFA987, #E54B4B)',
+    border: '1px solid',
+    borderColor: 'burntTangerine',
+    borderRadius: 'md',
+    boxShadow: 'md',
+    color: 'white',
+    _hover: {
+      bg: 'linear-gradient(to bottom, #FFB387, #F75151)', // hue shift on tangerine, brightness increase on imperial red
+      boxShadow: 'lg',
+      transform: 'scale(1.02)',
+    },
+    px: '8',
+    transition: 'all .3s',
+  },
+  secondary: {
+    bg: 'linear-gradient(to bottom, white, #F9F9F9)',
+    color: 'jet',
+    boxShadow: 'md',
+    border: '1px solid #E0E0E0',
+    _hover: {
+      boxShadow: 'lg',
+      transform: 'scale(1.02)',
+    },
+    px: '8',
+    transition: 'all .3s',
+  },
+};
+
+export default buttonVariants;

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -1,6 +1,7 @@
 import { extendTheme } from '@chakra-ui/react';
 import type { GlobalStyleProps } from '@chakra-ui/theme-tools';
 import { mode } from '@chakra-ui/theme-tools';
+import buttonVariants from './buttonVariants';
 import colors from './colors';
 
 // syntax: mode(light, dark)(props)
@@ -13,41 +14,24 @@ const styles = {
   }),
 };
 
-// button variants - needs its own module
-const buttonVariants = {
-  primary: {
-    bg: 'linear-gradient(to bottom, #FFA987, #E54B4B)',
-    borderRadius: 'md',
-    boxShadow: 'md',
-    color: 'white',
-    _hover: {
-      bg: 'linear-gradient(to bottom, #FFB387, #F75151)', // hue shift on tangerine, brightness increase on imperial red
-      boxShadow: 'lg',
-      transform: 'scale(1.02)',
-    },
-    px: '8',
-    transition: 'all .3s',
-  },
-};
-
 const config = {
   initialColorMode: 'light',
   useSystemColorMode: true,
 };
 
 const customTheme = extendTheme({
-  fonts: {
-    body: 'Open Sans, sans-serif',
-    heading: 'Onest, sans-serif',
-  },
+  colors,
+  config,
   components: {
     Button: {
       variants: buttonVariants,
     },
   },
-  config,
+  fonts: {
+    body: 'Open Sans, sans-serif',
+    heading: 'Onest, sans-serif',
+  },
   styles,
-  colors,
 });
 
 export default customTheme;


### PR DESCRIPTION
Adds the 'secondary' variants and updates the `theme` - did a little housekeeping 🧼🧹

The variant is a simple 'white on white' variant that works for both color modes for the time being 

<img width="305" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/1a2efffb-72a7-46fd-b36d-1afd3244c4d7">
