### PR TITLE
[frontend] feat: add glass icon and update theme

### DIFF
--- a/frontend/src/components/GlassIcon/GlassIcon.tsx
+++ b/frontend/src/components/GlassIcon/GlassIcon.tsx
@@ -1,7 +1,11 @@
-import React from 'react';
-import { Box, Center, useColorMode } from '@chakra-ui/react';
+import React, { ReactElement } from 'react';
+import { Box, Center, IconProps, useColorMode } from '@chakra-ui/react';
 
-const GlassIcon = ({ icon }: { icon: any }) => {
+type GlassIconProps = {
+  icon: ReactElement<IconProps>;
+};
+
+const GlassIcon = ({ icon }: GlassIconProps) => {
   const { colorMode } = useColorMode();
 
   const boxShadow =

--- a/frontend/src/components/GlassIcon/GlassIcon.tsx
+++ b/frontend/src/components/GlassIcon/GlassIcon.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { Box, Center, useColorMode } from '@chakra-ui/react';
+
+const GlassIcon = ({ icon }: { icon: any }) => {
+  const { colorMode } = useColorMode();
+
+  const boxShadow =
+    colorMode === 'light'
+      ? '0px 1px 10px .10px rgba(0, 0, 0, 0.10)'
+      : '0px 1px 10px .10px rgba(255, 255, 255, 0.3)'; // Light shadow for dark mode
+
+  const bg =
+    colorMode === 'light'
+      ? 'rgba(255, 255, 255, 0.2)'
+      : 'rgba(68, 65, 64, 0.6)'; // Based on 'jet'
+
+  const gradient =
+    colorMode === 'light'
+      ? 'linear-gradient(rgba(255, 255, 255, 0.5), transparent)'
+      : 'linear-gradient(rgba(30, 30, 36, 0.6), transparent)'; // Based on 'raisinBlack'
+
+  return (
+    <Box position="relative" mr="4">
+      <Center boxShadow={boxShadow} borderRadius="full" p={4} bg={bg}>
+        {icon}
+        <Box
+          position="absolute"
+          top="10%"
+          left="0"
+          right="0"
+          bottom="0"
+          bg={gradient}
+          borderRadius="full"
+          pointerEvents="none"
+        />
+      </Center>
+    </Box>
+  );
+};
+
+export default GlassIcon;

--- a/frontend/src/components/GlassIcon/index.ts
+++ b/frontend/src/components/GlassIcon/index.ts
@@ -1,0 +1,1 @@
+export { default } from './GlassIcon';

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,13 +1,18 @@
 import Link from 'next/link';
 import {
+  Center,
   Box,
   Flex,
   HStack,
   IconButton,
   useColorMode,
   useColorModeValue,
+  Heading,
+  Icon,
+  Text,
 } from '@chakra-ui/react';
 import { FaSun, FaMoon } from 'react-icons/fa';
+import { TbToolsKitchen2 } from 'react-icons/tb';
 
 const linkItems = [
   {
@@ -32,27 +37,30 @@ type NavLinkProps = {
 };
 
 const NavLink: React.FC<NavLinkProps> = ({ link: { name, href } }) => {
+  const linkHover = useColorModeValue('gray.100', 'raisinBlack');
   return (
     <Box
       as={Link}
       px={2}
       py={1}
       rounded="md"
+      fontWeight="semibold"
       href={href}
       _hover={{
         textDecoration: 'none',
-        bg: 'gray.200',
+        bg: linkHover,
       }}
       transition={'all 0.2s'}
     >
-      {name}
+      <Text>{name}</Text>
     </Box>
   );
 };
 
 const Header = () => {
   const { colorMode, toggleColorMode } = useColorMode();
-  const headerBg = useColorModeValue('gray.100', 'jet');
+  const headerBg = useColorModeValue('gray.50', 'jet');
+  const headerLogoColor = useColorModeValue('jet', 'gray.50');
 
   return (
     <Box bg={headerBg}>
@@ -62,12 +70,31 @@ const Header = () => {
         h={16}
         shadow="md"
         px={4}
+        w="full"
       >
-        <HStack spacing={8} alignItems="center">
-          {linkItems.map((link) => (
-            <NavLink link={link} key={link.name} />
-          ))}
-        </HStack>
+        <Flex>
+          <Center pr={8}>
+            <Icon
+              as={TbToolsKitchen2}
+              w={5}
+              h={5}
+              color={headerLogoColor}
+              mr={1}
+            />
+            <Heading
+              color={headerLogoColor}
+              fontWeight="semibold"
+              fontSize="24"
+            >
+              Dish Dollar
+            </Heading>
+          </Center>
+          <HStack spacing={8} alignItems="center">
+            {linkItems.map((link) => (
+              <NavLink link={link} key={link.name} />
+            ))}
+          </HStack>
+        </Flex>
         <IconButton
           aria-label="Toggle Dark Mode"
           icon={colorMode === 'dark' ? <FaSun /> : <FaMoon />}

--- a/frontend/src/components/Pantry/Pantry.tsx
+++ b/frontend/src/components/Pantry/Pantry.tsx
@@ -7,7 +7,7 @@ import {
   VStack,
   Heading,
   IconProps,
-  useColorMode,
+  useColorModeValue,
   Center,
   Divider,
 } from '@chakra-ui/react';
@@ -15,6 +15,7 @@ import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
 /** component imports */
 import Toolbar from './Toolbar';
 import PantryCard from '~/components/PantryCard';
+import GlassIcon from '~/components/GlassIcon';
 
 type PantryItem = {
   id: number;
@@ -92,9 +93,11 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
     'staple',
   ]);
 
+  const bg = useColorModeValue('white', 'jet');
+
   return (
     <Box height="calc(100vh - 180px)" p={8}>
-      <Heading color="raisinBlack">Pantry</Heading>
+      <Heading>Pantry</Heading>
       <Toolbar />
       <Grid
         h="50vh"
@@ -112,45 +115,24 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
             <Box
               key={type}
               w="100%"
-              bg="white"
+              bg={bg}
               borderRadius="lg"
               px={8}
               py={6}
               boxShadow="inset .5px 2px 5px 0px rgba(0, 0, 0, 0.10)"
             >
               <Flex mb={3} alignContent={'center'} alignItems={'center'}>
-                <Box position="relative" mr="4">
-                  <Center
-                    boxShadow="0px 1px 10px .10px rgba(0, 0, 0, 0.10)"
-                    borderRadius="full"
-                    p={4}
-                    bg="rgba(255, 255, 255, 0.2)"
-                  >
-                    {getIconForType(type)}
-
-                    <Box
-                      position="absolute"
-                      top="10%"
-                      left="0"
-                      right="0"
-                      bottom="0"
-                      bg="linear-gradient(rgba(255, 255, 255, 0.5), transparent)" // Glassy reflection gradient
-                      borderRadius="full"
-                      pointerEvents="none"
-                    />
-                  </Center>
-                </Box>
+                <GlassIcon icon={getIconForType(type)} />
                 <Flex direction="column" w="full">
                   <Heading
                     as="h3"
-                    color="jet"
                     fontSize="26"
                     textShadow="lg"
                     fontWeight="semibold"
                   >
                     {capitalizedType}
                   </Heading>
-                  <Divider borderColor="jet" opacity="30%" pt={2} />
+                  <Divider borderColor="raisinBlack" opacity="30%" pt={2} />
                 </Flex>
               </Flex>
               <VStack align="start" spacing={2}>

--- a/frontend/src/components/PantryCard/PantryCard.tsx
+++ b/frontend/src/components/PantryCard/PantryCard.tsx
@@ -14,7 +14,7 @@ type PantryCardProps = {
   //handleChange: (id: number, quantityInStock: number) => void; // will restore this when we have the slider
 };
 
-const PantryCard: React.FC<PantryCardProps> = ({ item }) => {
+const PantryCard = ({ item }: PantryCardProps) => {
   const activeCardDrawer = useAtomValue(activeCardDrawerAtom);
   const isActiveCard = activeCardDrawer?.id === item.id;
 

--- a/frontend/src/styles/theme.ts
+++ b/frontend/src/styles/theme.ts
@@ -11,6 +11,24 @@ const styles = {
       color: mode(colors.raisinBlack, colors.seashell)(props),
       bg: mode(colors.seashell, colors.raisinBlack)(props),
     },
+    h1: {
+      color: mode(colors.jet, 'white')(props),
+    },
+    h2: {
+      color: mode(colors.jet, 'white')(props),
+    },
+    h3: {
+      color: mode(colors.jet, 'white')(props),
+    },
+    h4: {
+      color: mode(colors.jet, 'white')(props),
+    },
+    h5: {
+      color: mode(colors.jet, 'white')(props),
+    },
+    h6: {
+      color: mode(colors.jet, 'white')(props),
+    },
   }),
 };
 


### PR DESCRIPTION
## Description 

- Updates the theme with more support for dark mode
- Adds Glass Icon component - This was created to give the pantry lists some depth, and a little bit of flair ✨ the goal for it being that each of these small areas looks like a "todo list" style/format list you'd write for yourself in your home - but with *more* info 

<img width="534" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/89f9b76f-2063-4cc9-9283-1227dd8da7a2">
<img width="537" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/a13a1b1d-0cc8-41a0-95f0-711f4ccef793">

The dark mode appearance could use some work - the shadow seems like it might be too intense? Idk, should play around in Figma before continuing to make choices in that regard. 


