### PR TITLE
[frontend] feat: InsetShadowBox layout component

### DIFF
--- a/frontend/src/components/Dashboard.tsx
+++ b/frontend/src/components/Dashboard.tsx
@@ -1,21 +1,8 @@
-import { Box, Flex, Heading, List, ListItem, Checkbox } from '@chakra-ui/react';
-
+import { Box, Flex, Heading } from '@chakra-ui/react';
 import SavedRecipeCard from './SavedRecipeCard';
+import ShoppingList from './ShoppingList';
 
 import { RECIPES } from '~/data';
-
-const shoppingList = [
-  'Eggs',
-  'Milk',
-  'Bread',
-  'Sour Cream',
-  'Butter',
-  'Salt',
-  'Pepper',
-  'Olive Oil',
-  'Chicken',
-  'Beef',
-];
 
 const Dashboard = () => {
   return (
@@ -32,19 +19,7 @@ const Dashboard = () => {
           ))}
         </Box>
 
-        {/* Shopping List */}
-        <Box flex="1" overflowY="auto" p={4}>
-          <Heading size="lg" mb={4}>
-            Shopping List
-          </Heading>
-          <List spacing={3}>
-            {shoppingList.map((item, index) => (
-              <ListItem key={index}>
-                <Checkbox size="lg">{item}</Checkbox>
-              </ListItem>
-            ))}
-          </List>
-        </Box>
+        <ShoppingList />
       </Flex>
     </Flex>
   );

--- a/frontend/src/components/Pantry/Pantry.tsx
+++ b/frontend/src/components/Pantry/Pantry.tsx
@@ -8,7 +8,6 @@ import {
   Heading,
   IconProps,
   useColorModeValue,
-  Center,
   Divider,
 } from '@chakra-ui/react';
 import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
@@ -16,6 +15,7 @@ import { TbPin, TbFridge, TbIceCream, TbApple, TbMilk } from 'react-icons/tb';
 import Toolbar from './Toolbar';
 import PantryCard from '~/components/PantryCard';
 import GlassIcon from '~/components/GlassIcon';
+import { InsetShadowBox } from '~/components/layout/containers';
 
 type PantryItem = {
   id: number;
@@ -112,15 +112,7 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
           // capitalize first letter of type
           const capitalizedType = type.charAt(0).toUpperCase() + type.slice(1);
           return (
-            <Box
-              key={type}
-              w="100%"
-              bg={bg}
-              borderRadius="lg"
-              px={8}
-              py={6}
-              boxShadow="inset .5px 2px 5px 0px rgba(0, 0, 0, 0.10)"
-            >
+            <InsetShadowBox key={type}>
               <Flex mb={3} alignContent={'center'} alignItems={'center'}>
                 <GlassIcon icon={getIconForType(type)} />
                 <Flex direction="column" w="full">
@@ -144,7 +136,7 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
                   />
                 ))}
               </VStack>
-            </Box>
+            </InsetShadowBox>
           );
         })}
       </Grid>

--- a/frontend/src/components/ShoppingList/ShoppingList.tsx
+++ b/frontend/src/components/ShoppingList/ShoppingList.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  Box,
+  Checkbox,
+  Divider,
+  Flex,
+  Icon,
+  Heading,
+  List,
+  ListItem,
+  Text,
+} from '@chakra-ui/react';
+import GlassIcon from '~/components/GlassIcon';
+import { InsetShadowBox } from '~/components/layout/containers';
+import { TbShoppingCart } from 'react-icons/tb';
+
+const shoppingList = [
+  'Eggs',
+  'Milk',
+  'Bread',
+  'Sour Cream',
+  'Butter',
+  'Salt',
+  'Pepper',
+  'Olive Oil',
+  'Chicken',
+  'Beef',
+];
+const ShoppingList = () => {
+  return (
+    <Box flex="1" overflowY="auto" p={4}>
+      <InsetShadowBox>
+        <Flex pb={8}>
+          <GlassIcon
+            icon={
+              <Icon as={TbShoppingCart} boxSize={8} color="atomicTangerine" />
+            }
+          />
+          <Box w="full">
+            <Flex justifyContent={'space-between'} alignItems={'center'}>
+              <Heading size="lg">Shopping List</Heading>
+              <Text
+                fontFamily="heading"
+                fontWeight="extrabold"
+                fontSize={22}
+                color="gray.300"
+                sx={{
+                  textShadow: 'inset 1px 1px 2px rgba(0, 0, 0, 0.95)',
+                }}
+                textShadow="inset 1px 1px 2px rgba(0, 0, 0, 0.95)"
+              >
+                0/10
+              </Text>
+            </Flex>
+            <Divider borderColor="raisinBlack" opacity="30%" mt={3} />
+          </Box>
+        </Flex>
+
+        <List spacing={3}>
+          {shoppingList.map((item, index) => (
+            <ListItem key={index}>
+              <Checkbox size="lg">{item}</Checkbox>
+            </ListItem>
+          ))}
+        </List>
+      </InsetShadowBox>
+    </Box>
+  );
+};
+
+export default ShoppingList;

--- a/frontend/src/components/ShoppingList/index.ts
+++ b/frontend/src/components/ShoppingList/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ShoppingList';

--- a/frontend/src/components/layout/containers/InsetShadowBox.tsx
+++ b/frontend/src/components/layout/containers/InsetShadowBox.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { Box, useColorModeValue } from '@chakra-ui/react';
+
+// RESEARCH: Is this better as a variant of the box, or as it's own layout component as it is now?
+
+//TODO: Types module - what's the best way? Research this
+// Make children prop required
+type PropsWithChildren<P = unknown> = P & { children: React.ReactNode };
+
+// explicit way of saying the component should only have a children prop
+type InsetShadowBoxProps = PropsWithChildren<{}>;
+
+const InsetShadowBox = ({ children }: InsetShadowBoxProps) => {
+  const bg = useColorModeValue('white', 'jet');
+  return (
+    <Box
+      w="full"
+      h="full"
+      bg={bg}
+      borderRadius="lg"
+      px={8}
+      py={6}
+      boxShadow="inset .5px 2px 5px 0px rgba(0, 0, 0, 0.10)"
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default InsetShadowBox;

--- a/frontend/src/components/layout/containers/index.ts
+++ b/frontend/src/components/layout/containers/index.ts
@@ -1,0 +1,3 @@
+import InsetShadowBox from './InsetShadowBox';
+
+export { default as InsetShadowBox } from './InsetShadowBox';


### PR DESCRIPTION
## Description

- Adds `containers` directory to `layout` 
- Adds `InsetShadowBox` to `containers` - this element is used to hold pantry lists (by category), and the shopping list on the home dashboard, and will probably be used in several other places. 
- `InsetShadowBox` is set up with both light and dark mode variants, has a slight inset shadow to give the area on the screen depth

<img width="435" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/3694a0d9-9cc6-4eb4-a0cf-29e33cb7741e">
<img width="446" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/5e207bf8-b1d6-4f4d-b3ff-3931faa2c30f">
