### PR TITLE
[frontend] feat: shopping list

### DIFF
--- a/frontend/src/components/PantryCard/PantryCard.tsx
+++ b/frontend/src/components/PantryCard/PantryCard.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-import { useAtomValue } from 'jotai';
-import { Box, Icon, useColorModeValue } from '@chakra-ui/react';
+import { Icon } from '@chakra-ui/react';
 import { TbStar } from 'react-icons/tb';
+import { useAtomValue } from 'jotai';
+import { activeCardDrawerAtom } from '~/lib/store/pantry.store';
 
+import { CardContainer } from '~/components/layout/containers';
 import ItemDetail from './ItemDetail';
 import ItemActions from './ItemActions';
 import PantryDrawer from './PantryDrawer';
 import { PantryItem } from '~/types';
-import { activeCardDrawerAtom } from '~/lib/store/pantry.store';
 
 type PantryCardProps = {
   item: PantryItem;
@@ -18,24 +19,9 @@ const PantryCard = ({ item }: PantryCardProps) => {
   const activeCardDrawer = useAtomValue(activeCardDrawerAtom);
   const isActiveCard = activeCardDrawer?.id === item.id;
 
-  const cardBg = useColorModeValue('white', 'jet');
   return (
     <>
-      <Box
-        className="pantry-card__container"
-        bg={cardBg}
-        borderRadius="lg"
-        boxShadow="md"
-        p={5}
-        w="full"
-        key={item.id}
-        position="relative"
-        _hover={{
-          transform: 'scale(1.02)',
-        }}
-        transition="all 0.2s ease-in-out"
-        zIndex={2}
-      >
+      <CardContainer>
         <ItemDetail {...item} />
         <Icon
           as={TbStar}
@@ -47,7 +33,7 @@ const PantryCard = ({ item }: PantryCardProps) => {
           cursor="pointer"
         />
         <ItemActions {...item} />
-      </Box>
+      </CardContainer>
       <PantryDrawer show={isActiveCard} item={item} />
     </>
   );

--- a/frontend/src/components/ShoppingList/List.tsx
+++ b/frontend/src/components/ShoppingList/List.tsx
@@ -2,34 +2,14 @@ import React from 'react';
 import {
   Box,
   Checkbox,
-  Divider,
   Flex,
   Icon,
-  Heading,
   List as ChakraList,
   ListItem,
   Text,
 } from '@chakra-ui/react';
-
-import GlassIcon from '~/components/GlassIcon';
-import { CardContainer, InsetShadowBox } from '~/components/layout/containers';
-import { TbShoppingCart, TbPencil, TbStar } from 'react-icons/tb';
-
-/**
- * <Box>
-      <Flex alignItems="center">
-        <Circle size="4" bg={getStockStatusColor(quantityInStock)} />
-
-        <Box ml={3}>
-          <Text fontSize="xs" fontStyle="italic">
-            {amountInStock}
-          </Text>
-          <Text fontSize="24px">{name}</Text>
-        </Box>
-      </Flex>
-    </Box>
-<Checkbox size="lg">{item}</Checkbox>
- */
+import { CardContainer } from '~/components/layout/containers';
+import { TbPencil, TbStar } from 'react-icons/tb';
 
 const List = ({ list }: { list: string[] }) => {
   return (

--- a/frontend/src/components/ShoppingList/List.tsx
+++ b/frontend/src/components/ShoppingList/List.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import {
+  Box,
+  Checkbox,
+  Divider,
+  Flex,
+  Icon,
+  Heading,
+  List as ChakraList,
+  ListItem,
+  Text,
+} from '@chakra-ui/react';
+
+import GlassIcon from '~/components/GlassIcon';
+import { CardContainer, InsetShadowBox } from '~/components/layout/containers';
+import { TbShoppingCart, TbPencil, TbStar } from 'react-icons/tb';
+
+/**
+ * <Box>
+      <Flex alignItems="center">
+        <Circle size="4" bg={getStockStatusColor(quantityInStock)} />
+
+        <Box ml={3}>
+          <Text fontSize="xs" fontStyle="italic">
+            {amountInStock}
+          </Text>
+          <Text fontSize="24px">{name}</Text>
+        </Box>
+      </Flex>
+    </Box>
+<Checkbox size="lg">{item}</Checkbox>
+ */
+
+const List = ({ list }: { list: string[] }) => {
+  return (
+    <ChakraList spacing={3}>
+      {list.map((item, index) => (
+        <ListItem key={index}>
+          <CardContainer>
+            <Box>
+              <Flex alignItems="center">
+                <Checkbox size="lg" />
+
+                <Box ml={3}>
+                  <Text fontSize="xs" fontStyle="italic">
+                    Text
+                  </Text>
+                  <Text fontSize="24px">{item}</Text>
+                </Box>
+              </Flex>
+            </Box>
+            <Icon
+              as={TbStar}
+              position="absolute"
+              top="12px"
+              right="14px"
+              boxSize="6"
+              color="#FFA987"
+              cursor="pointer"
+            />
+            <Flex position="absolute" bottom="12px" right="14px" gap={1}>
+              <Icon as={TbPencil} boxSize="6" color="#FFA987" />
+            </Flex>
+          </CardContainer>
+        </ListItem>
+      ))}
+    </ChakraList>
+  );
+};
+
+export default List;

--- a/frontend/src/components/ShoppingList/ShoppingList.tsx
+++ b/frontend/src/components/ShoppingList/ShoppingList.tsx
@@ -1,17 +1,8 @@
 import React from 'react';
-import {
-  Box,
-  Checkbox,
-  Divider,
-  Flex,
-  Icon,
-  Heading,
-  List,
-  ListItem,
-  Text,
-} from '@chakra-ui/react';
+import { Box, Divider, Flex, Icon, Heading, Text } from '@chakra-ui/react';
 import GlassIcon from '~/components/GlassIcon';
 import { InsetShadowBox } from '~/components/layout/containers';
+import List from './List';
 import { TbShoppingCart } from 'react-icons/tb';
 
 const shoppingList = [
@@ -30,7 +21,7 @@ const ShoppingList = () => {
   return (
     <Box flex="1" overflowY="auto" p={4}>
       <InsetShadowBox>
-        <Flex pb={8}>
+        <Flex py={2}>
           <GlassIcon
             icon={
               <Icon as={TbShoppingCart} boxSize={8} color="atomicTangerine" />
@@ -56,13 +47,7 @@ const ShoppingList = () => {
           </Box>
         </Flex>
 
-        <List spacing={3}>
-          {shoppingList.map((item, index) => (
-            <ListItem key={index}>
-              <Checkbox size="lg">{item}</Checkbox>
-            </ListItem>
-          ))}
-        </List>
+        <List list={shoppingList} />
       </InsetShadowBox>
     </Box>
   );

--- a/frontend/src/components/layout/containers/CardContainer.tsx
+++ b/frontend/src/components/layout/containers/CardContainer.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { Box, useColorModeValue } from '@chakra-ui/react';
+import type { PropsWithChildren } from '~/types';
+
+type CardContainerProps = PropsWithChildren<{}>;
+const CardContainer = ({ children }: CardContainerProps) => {
+  const bg = useColorModeValue('white', 'jet');
+  return (
+    <Box
+      className="card__container"
+      bg={bg}
+      borderRadius="lg"
+      boxShadow="md"
+      p={5}
+      w="full"
+      _hover={{
+        transform: 'scale(1.02)',
+      }}
+      position="relative"
+      transition="all 0.2s ease-in-out"
+    >
+      {children}
+    </Box>
+  );
+};
+
+export default CardContainer;

--- a/frontend/src/components/layout/containers/InsetShadowBox.tsx
+++ b/frontend/src/components/layout/containers/InsetShadowBox.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import { Box, useColorModeValue } from '@chakra-ui/react';
+import type { PropsWithChildren } from '~/types';
 
 // RESEARCH: Is this better as a variant of the box, or as it's own layout component as it is now?
-
-//TODO: Types module - what's the best way? Research this
-// Make children prop required
-type PropsWithChildren<P = unknown> = P & { children: React.ReactNode };
 
 // explicit way of saying the component should only have a children prop
 type InsetShadowBoxProps = PropsWithChildren<{}>;
@@ -21,6 +18,12 @@ const InsetShadowBox = ({ children }: InsetShadowBoxProps) => {
       px={8}
       py={6}
       boxShadow="inset .5px 2px 5px 0px rgba(0, 0, 0, 0.10)"
+      overflowY={'scroll'}
+      sx={{
+        '::-webkit-scrollbar': {
+          display: 'none',
+        },
+      }}
     >
       {children}
     </Box>

--- a/frontend/src/components/layout/containers/index.ts
+++ b/frontend/src/components/layout/containers/index.ts
@@ -1,3 +1,2 @@
-import InsetShadowBox from './InsetShadowBox';
-
 export { default as InsetShadowBox } from './InsetShadowBox';
+export { default as CardContainer } from './CardContainer';

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -84,3 +84,8 @@ export const pantryItemUnits = {
   staple: [...commonUnits],
   frozen: [...commonUnits],
 };
+
+// 🏗️ Component types
+//TODO: Types module - what's the best way? Research this
+// Make children prop required
+export type PropsWithChildren<P = unknown> = P & { children: React.ReactNode };


### PR DESCRIPTION
- Adds Shopping List directory and components
- Adds CardContainer to `layout/containers`
- Updates Shopping List on home page to more closely match list appearances on Pantry page

Before:
<img width="505" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/1c32890e-4ef6-41b4-864a-fa2e9f2bdb32">

After:
<img width="448" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/afe8ee4d-1268-46c5-a6d7-403a1bb64a24">

Future Considerations:

- On both Pantry lists and Shopping list the header sections should be sticky and should not scroll
