### PR TITLE
[frontend] feat: pantry card stacking context & UnitSelectForm

### DIFF
--- a/frontend/src/components/Pantry/Pantry.tsx
+++ b/frontend/src/components/Pantry/Pantry.tsx
@@ -118,7 +118,7 @@ const Pantry: React.FC<PantryProps> = ({ pantryItems }) => {
                 alignItems={'center'}
                 position="sticky"
                 top={0}
-                zIndex={1}
+                zIndex={3}
                 bg={bg}
               >
                 <Flex w="full" px={8} pt={6} mb={1}>

--- a/frontend/src/components/Pantry/Toolbar.tsx
+++ b/frontend/src/components/Pantry/Toolbar.tsx
@@ -19,7 +19,14 @@ function Toolbar() {
   const { colorMode } = useColorMode();
   const styles = inputStyles(colorMode);
   return (
-    <Flex py={6} justifyContent="space-between" alignItems="center" gap={3}>
+    <Flex
+      py={6}
+      justifyContent="space-between"
+      alignItems="center"
+      gap={3}
+      zIndex={4}
+      position="relative"
+    >
       {/* Filter dropdown */}
       <Menu>
         <MenuButton variant="secondary" as={Button}>

--- a/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
+++ b/frontend/src/components/PantryCard/PantryDrawer/PantryDrawer.tsx
@@ -39,7 +39,7 @@ const PantryDrawer: React.FC<PantryDrawerProps> = (props) => {
           mx="auto"
           bg="atomicTangerine"
           borderBottomRadius="lg"
-          zIndex={1}
+          zIndex={0}
           mt="-3"
           initial="closed"
           animate={show ? 'open' : 'closed'}

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -54,11 +54,14 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
           value={initialAmount}
           onChange={(value) => setInitialAmount(value)}
         />
-        <Select
+        {/* <Select
           options={unitOptions}
           value={unit}
           onChange={(value) => setUnit(value)}
-        />
+        /> 
+        Rethink this component/form
+        Maybe a numberInputField from chakra, that when clicked opens a modal with the selections for unit
+        */}
       </FormControl>
 
       <FormControl mb={4}>

--- a/frontend/src/components/forms/EditItemForm.pantry.tsx
+++ b/frontend/src/components/forms/EditItemForm.pantry.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
-import { Box, FormControl, FormLabel, Button } from '@chakra-ui/react';
+import { Box, FormControl, FormLabel, Button, Modal } from '@chakra-ui/react';
 import { PantryItem, pantryItemUnits } from '~/types';
-
+import UnitSelectForm from './UnitSelectForm.pantry';
 import { TwoPointNumberInput, Select } from '~/components/inputs';
 
 const EditItemForm = (item: PantryItem): JSX.Element => {
@@ -46,22 +46,14 @@ const EditItemForm = (item: PantryItem): JSX.Element => {
       <FormControl
         mb={4}
         display="grid"
-        gridTemplateColumns={'2fr 1fr'}
+        gridTemplateColumns={'1fr auto'}
         gap="2"
       >
-        {/* <FormLabel>Weight (volume)</FormLabel> */}
         <TwoPointNumberInput
           value={initialAmount}
           onChange={(value) => setInitialAmount(value)}
         />
-        {/* <Select
-          options={unitOptions}
-          value={unit}
-          onChange={(value) => setUnit(value)}
-        /> 
-        Rethink this component/form
-        Maybe a numberInputField from chakra, that when clicked opens a modal with the selections for unit
-        */}
+        <UnitSelectForm />
       </FormControl>
 
       <FormControl mb={4}>

--- a/frontend/src/components/forms/UnitSelectForm.pantry.tsx
+++ b/frontend/src/components/forms/UnitSelectForm.pantry.tsx
@@ -1,0 +1,77 @@
+import React, { useState } from 'react';
+import {
+  Button,
+  Flex,
+  Grid,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  Switch,
+  Text,
+  HStack,
+} from '@chakra-ui/react';
+import { useDisclosure } from '@chakra-ui/react';
+
+const UnitSelectForm: React.FC = () => {
+  const [unit, setUnit] = useState('kg'); // default to 'kg'
+  const [isMetric, setIsMetric] = useState(true); // default to metric units
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+
+  const handleUpdateItemUnit = (selectedUnit: string) => {
+    setUnit(selectedUnit);
+    onClose();
+    // Logic for updating the unit for the item (e.g., send data to server)
+  };
+
+  const unitsByCategory = {
+    metric: ['kg', 'g', 'ml', 'L'],
+    imperial: ['lb', 'oz', 'cup', 'gal'],
+  };
+
+  return (
+    <>
+      <Button variant="secondary" onClick={onOpen}>
+        {unit}
+      </Button>
+
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent px={4} py={8}>
+          <Flex justifyContent="space-between" alignItems="center" mb={4}>
+            <Text>Select Unit:</Text>
+            <HStack spacing={4}>
+              <Text>Imperial</Text>
+              <Switch
+                isChecked={isMetric}
+                onChange={() => setIsMetric(!isMetric)}
+              />
+              <Text>Metric</Text>
+            </HStack>
+          </Flex>
+          <Grid templateColumns="repeat(2, 1fr)" gap={4}>
+            {isMetric
+              ? unitsByCategory.metric.map((unitOption) => (
+                  <Button
+                    key={unitOption}
+                    onClick={() => handleUpdateItemUnit(unitOption)}
+                  >
+                    {unitOption}
+                  </Button>
+                ))
+              : unitsByCategory.imperial.map((unitOption) => (
+                  <Button
+                    key={unitOption}
+                    onClick={() => handleUpdateItemUnit(unitOption)}
+                  >
+                    {unitOption}
+                  </Button>
+                ))}
+          </Grid>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default UnitSelectForm;

--- a/frontend/src/components/inputs/Select/index.tsx
+++ b/frontend/src/components/inputs/Select/index.tsx
@@ -1,4 +1,5 @@
 import {
+  Box,
   Flex,
   Icon,
   Menu,
@@ -29,7 +30,7 @@ const Select: React.FC<SelectProps> = ({ options, value, onChange }) => {
   return (
     <Menu>
       {({ isOpen }) => (
-        <>
+        <Box zIndex={100} position="relative">
           <MenuButton {...styles} borderRadius="md" overflow={'hidden'}>
             <Flex
               px={2}
@@ -54,7 +55,7 @@ const Select: React.FC<SelectProps> = ({ options, value, onChange }) => {
               />
             ))}
           </MenuList>
-        </>
+        </Box>
       )}
     </Menu>
   );

--- a/frontend/src/components/layout/containers/CardContainer.tsx
+++ b/frontend/src/components/layout/containers/CardContainer.tsx
@@ -18,6 +18,7 @@ const CardContainer = ({ children }: CardContainerProps) => {
       }}
       position="relative"
       transition="all 0.2s ease-in-out"
+      zIndex={2}
     >
       {children}
     </Box>


### PR DESCRIPTION
## Description:

- Solves stacking context bugs between InsetShadowBox and the drop downs on pages 
- Adds a UnitSelectForm to answer for dropdown in the PantryCard drawer - because this was the child of a parent with a lower zIndex, it clipped behind various elements no matter how I tried to solve for it. So Instead I created a modal. 

I like the modal solution because it solves for the clipping (obviously), but it also takes a way a really long dropdown list where it would be easy to make the wrong selection, or accidentally update the selection - and it makes it really easy for the user to see what unit they're selecting.
Furthermore they can sort by Imperial or Metric system, with more sub-organization coming. 

<img width="1267" alt="image" src="https://github.com/ash-bergs/dish-dollar/assets/65979049/ab7a07a6-9e25-4966-8931-c0a7adaab449">
